### PR TITLE
Let's remove duplicate PostHTML dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "eslint": "^1.10.3",
-    "posthtml": "^0.8.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2"
   },


### PR DESCRIPTION
It looks like `posthtml` dependency is in normal dependencies and also in Dev dependencies. Let's remove Dev-one.